### PR TITLE
BACKLOG-23333: JS entrypoint is now at the root

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -18,7 +18,7 @@
     "module-dependencies": "default",
     "module-type": "$$MODULE_TYPE$$",
     "module-type-comment": "Use templatesSet in the module type to declare a template set",
-    "server": "dist/main.js",
+    "server": "main.js",
     "static-resources": "/icons,/images,/javascript,/locales"
   },
   "dependencies": {


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

https://jira.jahia.org/browse/BACKLOG-23333

## Description

Leftover from https://jira.jahia.org/browse/BACKLOG-23333 task to update the `Jahia-NPM-InitScript` to match the new folder structure, as the JavaScript entry point file is now generated in the root folder of the NPM package (instead of the `dist/` folder).

