### PR TITLE
BACKLOG-23352: Dynamically add @jahia/javascript-modules-library

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,6 +130,12 @@ fs.mkdirSync(path.join(projectDir, 'settings', 'content-editor-forms'), {recursi
 fs.mkdirSync(path.join(projectDir, 'settings', 'content-editor-forms', 'forms'), {recursive: true});
 fs.mkdirSync(path.join(projectDir, 'settings', 'content-editor-forms', 'fieldsets'), {recursive: true});
 
+// Add the latest @jahia/javascript-modules-library
+execSync('yarn add @jahia/javascript-modules-library', {cwd: projectDir});
+const javascriptModulesLibraryInfo = execSync('yarn info @jahia/javascript-modules-library version --json', {cwd: projectDir, encoding: 'utf8'});
+const javascriptModulesLibraryInfoValue = JSON.parse(javascriptModulesLibraryInfo).value;
+console.log(`Added ${javascriptModulesLibraryInfoValue} to the project`);
+
 console.log(`Created \x1B[1m${projectName}\x1B[0m at \x1B[1m${projectDir}\x1B[0m`);
 console.log('Success! Your new project is ready.');
 console.log('You can now change into your project and launch "yarn" to install everything to get started.');

--- a/template/package.json
+++ b/template/package.json
@@ -22,7 +22,6 @@
     "static-resources": "/icons,/images,/javascript,/locales"
   },
   "dependencies": {
-    "@jahia/javascript-modules-library": "^0.0.4",
     "graphql": "^16.7.1",
     "i18next": "^23.10.1",
     "react": "^18.2.0",

--- a/tests/create-templatesSet-project.test.js
+++ b/tests/create-templatesSet-project.test.js
@@ -114,6 +114,10 @@ describe('npx @jahia/create-module', () => {
             });
             expect(entries.length).toBe(expectedFilesInArchive.length);
         });
+
+        // Make sure the package.json contains the dependency @jahia/javascript-modules-library
+        const packageJson = JSON.parse(fs.readFileSync(path.join(projectPath, 'package.json'), 'utf8'));
+        expect(packageJson.dependencies['@jahia/javascript-modules-library']).toBeDefined();
     }
     );
 });


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

https://jira.jahia.org/browse/BACKLOG-23352
## Description

Add the latest version of `@jahia/javascript-modules-library` when creating a new project using https://www.npmjs.com/package/@jahia/create-module package with the command:
```
npx @jahia/create-module@latest project-name [module-type] [namespace-definitions]
```

The main benefit is that we no longer need to update the `package.json` of the template to bump the version of `@jahia/javascript-modules-library` when a new version is released.
<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->


## Tests

The following are included in this PR
- [x] Integration Tests
